### PR TITLE
Adding feature_colname attribute

### DIFF
--- a/R/marker_intensity_boxplot.R
+++ b/R/marker_intensity_boxplot.R
@@ -12,17 +12,17 @@
 #' marker_intensity_boxplot(SPIAT::simulated_image, "Immune_marker1")
 #' @export
 
-marker_intensity_boxplot <- function(spe_object, marker){
+marker_intensity_boxplot <- function(spe_object, marker, feature_colname = "Phenotype"){
     # setting these variables to NULL as otherwise get "no visible binding for global variable" in R check
     intensity <- NULL
 
     formatted_data <- bind_info(spe_object)
 
     #selecting cells that do express the marker
-    intensity_true <- formatted_data[grepl(marker, formatted_data$Phenotype), ]
+    intensity_true <- formatted_data[grepl(marker, formatted_data[[feature_colname]]), ]
 
     #selecting cells that do not contain the marker
-    intensity_false <- formatted_data[!grepl(marker, formatted_data$Phenotype), ] #for multiple entries that does not contain marker
+    intensity_false <- formatted_data[!grepl(marker, formatted_data[[feature_colname]]), ] #for multiple entries that does not contain marker
 
     #select the specific marker and add a boolean of intensity
     if (nrow(intensity_true) != 0) {

--- a/R/marker_intensity_boxplot.R
+++ b/R/marker_intensity_boxplot.R
@@ -5,6 +5,7 @@
 #' @param spe_object SpatialExperiment object in the form of the output of
 #'   \code{\link{format_image_to_spe}}.
 #' @param marker String. Marker being queried.
+#' @param feature_colname String. Column containing marker information
 #' @import dplyr
 #' @import ggplot2
 #' @return A plot is returned

--- a/R/plot_cell_marker_levels.R
+++ b/R/plot_cell_marker_levels.R
@@ -8,6 +8,7 @@
 #' @param spe_object SpatialExperiment object in the form of the output of
 #'   \code{\link{format_image_to_spe}}.
 #' @param marker String. Marker to plot.
+#' @param feature_colname String. Column containing marker information
 #' @import dplyr
 #' @import ggplot2
 #' @return A plot is returned

--- a/R/plot_cell_marker_levels.R
+++ b/R/plot_cell_marker_levels.R
@@ -15,7 +15,7 @@
 #' plot_cell_marker_levels(SPIAT::simulated_image, "Immune_marker1")
 #' @export
 
-plot_cell_marker_levels <- function(spe_object, marker) {
+plot_cell_marker_levels <- function(spe_object, marker, feature_colname = "Phenotype") {
 
     Cell.X.Position <- Cell.Y.Position <- NULL
     
@@ -31,9 +31,9 @@ plot_cell_marker_levels <- function(spe_object, marker) {
     
     #selecting cells that do not contain the marker
     #for one entry that is not marker
-    rows <- formatted_data[formatted_data$Phenotype != marker, ] 
+    rows <- formatted_data[formatted_data[[feature_colname]] != marker, ] 
     #for multiple entries that does not contain marker
-    rows <- rows[!grepl(marker, rows$Phenotype), ] 
+    rows <- rows[!grepl(marker, rows[[feature_colname]]), ] 
     
     #for those cell without the marker, set marker intensity to 0
     #and merge the formatted_data


### PR DESCRIPTION
Some of the marker quality control functions default to the original Phenotype column. This is usually no problem, but we occasionally receive data with untidy phenotypes and clean them using the define_celltypes function. 

In these cases the changed functions cannot access the tidy phenotypes. Adding an optional argument and changing the way the feature column is called in the function makes this possible.

Adding the default argument "Phenotype" makes this change compatible with existing code.